### PR TITLE
dds2tex: Adding support for swizzling textures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,25 @@
 
 These tools are designed to convert texture (TEX <-> DDS) and audio (SMP <-> OGG) assets for use in Ghostbusters: The Video Game and its remastered version.
 
-- **tex2dds**: Converts TEX files to DDS for both the original and remastered versions of Ghostbusters: The Video Game.
-- **dds2tex**: Converts DDS files back to TEX (tested with the remastered version, theoretically compatible with the original).
-- **smp2ogg**: Converts SMP audio files to OGG for the remastered game.
-- **ogg2smp**: Converts OGG audio files back to SMP for the remastered game.
+**tex2dds:** Converts TEX files, whether from the original game (PC, PS3, Xbox 360) or the remastered version (PC), into DDS format.
+
+**dds2tex:** Converts DDS files to TEX format for both the original game (PC, PS3, Xbox 360) and the remastered version (PC).
+
+**smp2ogg:** Converts SMP audio files from the remastered version (PC) into OGG format.
+
+**ogg2smp:** Converts OGG audio files to SMP format specifically for the remastered version (PC).
 
 
-# Build Instructions:
+# General build Instructions:
 
-To compile these tools on Linux, use the following command:
+To compile these tools, use the following command:
 
 `g++ -static -o <toolname> <toolname>.cpp`
 
 To cross-compile for Windows (from Linux), use:
 
 `x86_64-w64-mingw32-g++ -static -o <toolname> <toolname>.cpp`
+
 
 # Usage:
 
@@ -25,10 +29,11 @@ Run the converter by specifying the input asset file:
 $ ./<toolname> <input_file> [OPTIONS]
 ```
 ```
-Options:
-  -o, --output <output_file>        Specify the output file path and name
-  -q, --quiet                       Disable output messages
-  -h, --help                        Show this help message and exit
+Common options:
+  -i, --input <input_file>          Specify the input file path and name.
+  -o, --output <output_file>        Specify the output file path and name.
+  -q, --quiet                       Disable output messages.
+  -h, --help                        Show this help message and exit.
 ```
 
 Alternatively, you can drag and drop an asset file onto the executable.

--- a/dds2tex/README.md
+++ b/dds2tex/README.md
@@ -26,10 +26,10 @@ $ ./dds2tex <input_file.dds> [OPTIONS]
 ```
 ```
 Options:
-  -i, --input <input_file.dds>          Specify the input DDS file path and name.
-  -o, --output <output_file.tex>        Specify the output TEX file path and name.
-  -p, --platform <platform>             Output tex file for the <platform> version of the game.
-                                        Supported platforms are 'pc', 'ps3' or 'xbox360'. Default is 'pc'.
+  -i, --input <input_file.dds>      Specify the input DDS file path and name.
+  -o, --output <output_file.tex>    Specify the output TEX file path and name.
+  -p, --platform <platform>         Output tex file for the <platform> version of the game.
+                                    Supported platforms are 'pc', 'ps3' or 'xbox360'. Default is 'pc'.
   -q, --quiet                       Disable output messages.
   -h, --help                        Show this help message and exit.
 ```

--- a/dds2tex/README.md
+++ b/dds2tex/README.md
@@ -1,0 +1,44 @@
+# Ghostbusters: The Video Game Remastered Asset Converters (dds2tex)
+
+**dds2tex:** Converts DDS files to TEX format for both the original game (PC, PS3, Xbox 360) and the remastered version (PC).
+
+**Note:** The program will automatically swizzle textures when required.
+This is necessary for certain textures used in the PS3 version and for all textures in the Xbox 360 version (the PC version does not require swizzling).
+Keep in mind that this swizzling feature is experimental, and the resulting TEX files may be inaccurate or could potentially cause the game to crash.
+
+
+# Build Instructions:
+
+To compile this tool, use the following command:
+
+`g++ -static -o dds2tex dds2tex.cpp`
+
+To cross-compile for Windows (from Linux), use:
+
+`x86_64-w64-mingw32-g++ -static -o dds2tex dds2tex.cpp`
+
+
+# Usage:
+
+Run the converter by specifying the input DDS file:
+```sh
+$ ./dds2tex <input_file.dds> [OPTIONS]
+```
+```
+Options:
+  -i, --input <input_file.dds>          Specify the input DDS file path and name.
+  -o, --output <output_file.tex>        Specify the output TEX file path and name.
+  -p, --platform <platform>             Output tex file for the <platform> version of the game.
+                                        Supported platforms are 'pc', 'ps3' or 'xbox360'. Default is 'pc'.
+  -q, --quiet                       Disable output messages.
+  -h, --help                        Show this help message and exit.
+```
+
+Alternatively, you can drag and drop a DDS file onto the executable.
+
+
+# Mass convert assets
+
+Script for batch processing multiple DDSs is available on NexusMods:
+
+[GBTVGR dds2tex Mass Converter](https://www.nexusmods.com/ghostbustersthevideogameremastered/mods/48)

--- a/dds2tex/dds2tex.cpp
+++ b/dds2tex/dds2tex.cpp
@@ -18,6 +18,9 @@
 #include <getopt.h>
 #include <algorithm>
 #include <cctype>
+#include <cstring>
+#include <stdexcept>
+#include <cstdint>
 
 std::string platform = "pc";	// PC is the default platform
 bool forcedxtone = false;	// DXT1 compression mode flag
@@ -68,6 +71,116 @@ struct TEX_Header {
 	DWORD dwUnknown30 = 0;			// Placeholder
 };
 
+inline uint32_t swap16(uint16_t val) {
+	return (val << 8) | (val >> 8);
+}
+
+inline int xgAddress2DTiledX(int blockOffset, int widthInBlocks, int texelBytePitch) {
+	int alignedWidth = (widthInBlocks + 31) & ~31;
+	int logBpp = (texelBytePitch >> 2) + ((texelBytePitch >> 1) >> (texelBytePitch >> 2));
+	int offsetByte = blockOffset << logBpp;
+	int offsetTile = (((offsetByte & ~0xFFF) >> 3) + ((offsetByte & 0x700) >> 2) + (offsetByte & 0x3F));
+	int offsetMacro = offsetTile >> (7 + logBpp);
+
+	int macroX = (offsetMacro % (alignedWidth >> 5)) << 2;
+	int tile = (((offsetTile >> (5 + logBpp)) & 2) + (offsetByte >> 6)) & 3;
+	int macro = (macroX + tile) << 3;
+	int micro = ((((offsetTile >> 1) & ~0xF) + (offsetTile & 0xF)) & ((texelBytePitch << 3) - 1)) >> logBpp;
+
+	return macro + micro;
+}
+
+inline int xgAddress2DTiledY(int blockOffset, int widthInBlocks, int texelBytePitch) {
+	int alignedWidth = (widthInBlocks + 31) & ~31;
+	int logBpp = (texelBytePitch >> 2) + ((texelBytePitch >> 1) >> (texelBytePitch >> 2));
+	int offsetByte = blockOffset << logBpp;
+	int offsetTile = (((offsetByte & ~0xFFF) >> 3) + ((offsetByte & 0x700) >> 2) + (offsetByte & 0x3F));
+	int offsetMacro = offsetTile >> (7 + logBpp);
+
+	int macroY = (offsetMacro / (alignedWidth >> 5)) << 2;
+	int tile = ((offsetTile >> (6 + logBpp)) & 1) + ((offsetByte & 0x800) >> 10);
+	int macro = (macroY + tile) << 3;
+	int micro = (((offsetTile & ((texelBytePitch << 6) - 1 & ~0x1F)) + ((offsetTile & 0xF) << 1)) >> (3 + logBpp)) & ~1;
+
+	return macro + micro + ((offsetTile & 0x10) >> 4);
+}
+
+void swizzle_x360(const std::vector<uint8_t>& input, std::vector<uint8_t>& output, int width, int height, int block_pixel_size, int texel_byte_pitch) {
+	const int widthInBlocks = width / block_pixel_size;
+	const int heightInBlocks = height / block_pixel_size;
+
+	std::vector<uint8_t> swapped(input.size());
+	if (input.size() % 2 != 0)
+		throw std::runtime_error("Data size must be a multiple of 2 bytes!");
+
+	for (size_t i = 0; i < input.size(); i += 2) {
+		swapped[i]	 = input[i + 1];
+		swapped[i + 1] = input[i];
+	}
+
+	output.resize(input.size());
+
+	for (int j = 0; j < heightInBlocks; ++j) {
+		for (int i = 0; i < widthInBlocks; ++i) {
+			int blockOffset = j * widthInBlocks + i;
+			int x = xgAddress2DTiledX(blockOffset, widthInBlocks, texel_byte_pitch);
+			int y = xgAddress2DTiledY(blockOffset, widthInBlocks, texel_byte_pitch);
+
+			int srcByteOffset = j * widthInBlocks * texel_byte_pitch + i * texel_byte_pitch;
+			int dstByteOffset = y * widthInBlocks * texel_byte_pitch + x * texel_byte_pitch;
+
+			if (dstByteOffset + texel_byte_pitch > output.size() ||
+				srcByteOffset + texel_byte_pitch > swapped.size())
+				continue;
+
+			std::memcpy(&output[srcByteOffset], &swapped[dstByteOffset], texel_byte_pitch);
+		}
+	}
+}
+
+inline size_t calculate_morton_index(size_t t, size_t width, size_t height) {
+	size_t num1 = 1, num2 = 1, num3 = t;
+	size_t t_width = width, t_height = height;
+	size_t num6 = 0, num7 = 0;
+
+	while (t_width > 1 || t_height > 1) {
+		if (t_width > 1) {
+			num6 += num2 * (num3 & 1);
+			num3 >>= 1;
+			num2 *= 2;
+			t_width >>= 1;
+		}
+		if (t_height > 1) {
+			num7 += num1 * (num3 & 1);
+			num3 >>= 1;
+			num1 *= 2;
+			t_height >>= 1;
+		}
+	}
+
+	return num7 * width + num6;
+}
+
+void swizzle_morton(const std::vector<uint8_t>& input, std::vector<uint8_t>& output, int width, int height, int bytes_per_pixel, int block_width_height = 1) {
+	int block_size_bytes = bytes_per_pixel * block_width_height * block_width_height;
+
+	int blocks_w = width / block_width_height;
+	int blocks_h = height / block_width_height;
+	int total_blocks = blocks_w * blocks_h;
+
+	output.resize(input.size());
+	size_t source_index = 0;
+
+	for (int t = 0; t < total_blocks; ++t) {
+		size_t index = calculate_morton_index(t, blocks_w, blocks_h);
+		size_t destination_index = index * block_size_bytes;
+
+		std::memcpy(&output[source_index], &input[destination_index], block_size_bytes);
+
+		source_index += block_size_bytes;
+	}
+}
+
 // Function to create output directory
 void createDirectories(const std::string& path) {
 	std::filesystem::create_directories(path);
@@ -76,7 +189,7 @@ void createDirectories(const std::string& path) {
 // Function to print the help message
 void printHelpMessage() {
 	std::cout << std::endl;
-	std::cout << "👻 GBTVGR DDS to TEX Converter v0.3.0" << std::endl;
+	std::cout << "👻 GBTVGR DDS to TEX Converter v0.4.0" << std::endl;
 	std::cout << std::endl;
 	std::cout << "Usage: dds2tex <input_file.dds> [options]" << std::endl;
 	std::cout << std::endl;
@@ -84,7 +197,7 @@ void printHelpMessage() {
 	std::cout << "  -i, --input <input_file.dds>		Specify the input DDS file path and name." << std::endl;
 	std::cout << "  -o, --output <output_file.tex>	Specify the output TEX file path and name." << std::endl;
 	std::cout << "  -p, --platform <platform>		Output tex file for the <platform> version of the game." << std::endl;
-	std::cout << "					Supported platforms are 'pc' or 'ps3'. Default is 'pc'." << std::endl;
+	std::cout << "					Supported platforms are 'pc', 'ps3' or 'xbox360'. Default is 'pc'." << std::endl;
 	std::cout << "  -q, --quiet				Disable output messages." << std::endl;
 	std::cout << "  -h, --help				Show this help message and exit." << std::endl;
 	std::cout << std::endl;
@@ -108,6 +221,8 @@ DWORD mapDDSPixelFormatToTEX(const DDS_PIXELFORMAT& ddsPixelFormat, DWORD cubema
 			return 0x2b;
 		} else if (platform == "ps3") {
 			return 0x2c;
+		} else if (platform == "xbox360") {
+			return 0x28;
 		}
 	}
 	if (ddsPixelFormat.dwFourCC == 0x33545844) {	// "DXT3"
@@ -118,22 +233,22 @@ DWORD mapDDSPixelFormatToTEX(const DDS_PIXELFORMAT& ddsPixelFormat, DWORD cubema
 			return 0x32;
 		} else if (platform == "ps3") {
 			return 0x34;
+		} else if (platform == "xbox360") {
+			return 0x33;
 		}
 	}
 	if (ddsPixelFormat.dwRGBBitCount == 32 && ddsPixelFormat.dwRBitMask == 0x00FF0000) {	// A8R8G8B8
 		if (platform == "pc") {
 			return cubemapFlag ? 0x18 : 0x03;	// (0x18 if cubemap)
 		} else if (platform == "ps3") {
-			std::cerr << "* ERROR: Unsupported DDS format. Save the DDS as BC3 / DXT5 first." << std::endl;
-			return 0;
-			//return cubemapFlag ? 0x26 : 0x27;	// (0x26 if cubemap)
+			return cubemapFlag ? 0x26 : 0x27;	// (0x26 if cubemap)
+		} else if (platform == "xbox360") {
+			return cubemapFlag ? 0x36 : 0x16;	// (0x26 if cubemap)
 		}
 	}
 	if (platform == "ps3") {
 		if (ddsPixelFormat.dwRGBBitCount == 32 && ddsPixelFormat.dwBBitMask == 0x00FF0000) {	// RGBA8888
-			std::cerr << "* ERROR: Unsupported DDS format. Save the DDS as BC3 / DXT5 first." << std::endl;
-			return 0;
-			//return cubemapFlag ? 0x26 : 0x27;	// A8R8G8B8 (0x26 if cubemap)
+			return cubemapFlag ? 0x26 : 0x27;	// A8R8G8B8 (0x26 if cubemap)
 		}
 	}
 	if (ddsPixelFormat.dwRGBBitCount == 64 && ddsPixelFormat.dwFourCC == 0x71) {	// A16B16G16R16F
@@ -144,6 +259,8 @@ DWORD mapDDSPixelFormatToTEX(const DDS_PIXELFORMAT& ddsPixelFormat, DWORD cubema
 			return 0x2f;
 		} else if (platform == "ps3") {
 			return 0x31;
+		} else if (platform == "xbox360") {
+			return 0x30;
 		}
 	}
 	if (ddsPixelFormat.dwRGBBitCount == 16 && ddsPixelFormat.dwRBitMask == 0xF800) {	// R5G6B5
@@ -249,9 +366,9 @@ int main(int argc, char* argv[]) {
 		std::cerr << "* ERROR: No input file specified." << std::endl;
 	}
 
-	if (platform != "pc" && platform != "ps3") {
+	if (platform != "pc" && platform != "ps3" && platform != "xbox360") {
 		argError = true;
-		std::cerr << "* ERROR: Unsupported platform: '" << platform << "'. Supported platforms are 'pc' or 'ps3'." << std::endl;
+		std::cerr << "* ERROR: Unsupported platform: '" << platform << "'. Supported platforms are 'pc', 'ps3' or 'xbox360'." << std::endl;
 	}
 
 	if (argError) {
@@ -326,6 +443,56 @@ int main(int argc, char* argv[]) {
 	std::string pathTo = std::filesystem::path(outputFile).parent_path().string();
 	std::string file = std::filesystem::path(outputFile).stem().string();
 
+	bool needsSwizzle = false;
+	std::string swizzleType;
+	int blockWidthHeight;
+	int blockPixelSize;
+	int texelBytePitch;
+	
+	switch (texHeader.dwFormat) {
+	case 0x27:	// PS3 OK
+		needsSwizzle = true;
+		swizzleType = "morton";
+		blockWidthHeight = 1;
+		break;
+	case 0x16:	// XBOX360
+		needsSwizzle = true;
+		swizzleType = "x360";
+		blockPixelSize = 1;
+		texelBytePitch = 4;
+		break;
+	case 0x28:	// XBOX360
+		needsSwizzle = true;
+		swizzleType = "x360";
+		blockPixelSize = 4;
+		texelBytePitch = 8;
+		break;
+	case 0x26:	// PS3
+	case 0x36:	// XBOX360
+	case 0x1b:	// XBOX360
+		needsSwizzle = true;
+		swizzleType = "morton";
+		blockWidthHeight = 1;
+		break;
+	case 0x31:	// PS3
+		needsSwizzle = true;
+		swizzleType = "morton";
+		blockWidthHeight = 1;
+		break;
+	case 0x30:	// XBOX360
+		needsSwizzle = true;
+		swizzleType = "x360";
+		blockPixelSize = 1;
+		texelBytePitch = 2;
+		break;
+	case 0x33:	// XBOX360
+		needsSwizzle = true;
+		swizzleType = "x360";
+		blockPixelSize = 4;
+		texelBytePitch = 16;
+		break;
+	}
+
 	// Create output directory if not exists
 	createDirectories(pathTo);
 
@@ -334,6 +501,20 @@ int main(int argc, char* argv[]) {
 	if (!texFile.is_open()) {
 		std::cerr << "* ERROR: Unable to open TEX file: " << outputFile << std::endl;
 		return 1;
+	}
+
+	if (needsSwizzle) {
+		std::vector<uint8_t> swizzled(ddsData.size());
+		if (swizzleType == "x360") {
+			swizzle_x360(reinterpret_cast<const std::vector<uint8_t>&>(ddsData), swizzled, texHeader.dwWidth, texHeader.dwHeight, blockPixelSize, texelBytePitch);
+		} else if (swizzleType == "morton") {
+			int bytesPerPixel = (ddsHeader.ddspf.dwRGBBitCount + 7) / 8;
+			swizzle_morton(reinterpret_cast<const std::vector<uint8_t>&>(ddsData), swizzled, texHeader.dwWidth, texHeader.dwHeight, bytesPerPixel, blockWidthHeight);
+			for (size_t i = 0; i + 1 < swizzled.size(); i += bytesPerPixel) {
+				std::reverse(swizzled.begin() + i, swizzled.begin() + i + bytesPerPixel);
+			}
+		}
+		ddsData = std::vector<char>(swizzled.begin(), swizzled.end());
 	}
 
 	texFile.write(reinterpret_cast<const char*>(&texHeader), sizeof(TEX_Header));

--- a/ogg2smp/README.md
+++ b/ogg2smp/README.md
@@ -1,0 +1,38 @@
+# Ghostbusters: The Video Game Remastered Asset Converters (ogg2smp)
+
+**ogg2smp:** Converts OGG audio files to SMP format specifically for the remastered version (PC).
+
+
+# Build Instructions:
+
+To compile this tool, use the following command:
+
+`g++ -static -o ogg2smp ogg2smp.cpp -lvorbisfile -lvorbis -logg -pthread`
+
+To cross-compile for Windows (from Linux), use:
+
+`x86_64-w64-mingw32-g++ -static -o ogg2smp ogg2smp.cpp -lvorbisfile -lvorbis -logg -pthread`
+
+
+# Usage:
+
+Run the converter by specifying the input OGG file:
+```sh
+$ ./ogg2smp <input_file.ogg> [OPTIONS]
+```
+```
+Options:
+  -i, --input <input_file.ogg>      Specify the input OGG file path and name.
+  -o, --output <output_file.smp>    Specify the output SMP file path and name.
+  -q, --quiet                       Disable output messages.
+  -h, --help                        Show this help message and exit.
+```
+
+Alternatively, you can drag and drop an OGG file onto the executable.
+
+
+# Mass convert assets
+
+Script for batch processing multiple OGGs is available on NexusMods:
+
+[GBTVGR ogg2smp Mass Converter](https://www.nexusmods.com/ghostbustersthevideogameremastered/mods/47)

--- a/smp2ogg/README.md
+++ b/smp2ogg/README.md
@@ -1,0 +1,38 @@
+# Ghostbusters: The Video Game Remastered Asset Converters (smp2ogg)
+
+**smp2ogg:** Converts SMP audio files from the remastered version (PC) into OGG format.
+
+
+# Build Instructions:
+
+To compile this tool, use the following command:
+
+`g++ -static -o smp2ogg smp2ogg.cpp`
+
+To cross-compile for Windows (from Linux), use:
+
+`x86_64-w64-mingw32-g++ -static -o smp2ogg smp2ogg.cpp`
+
+
+# Usage:
+
+Run the converter by specifying the input SMP file:
+```sh
+$ ./smp2ogg <input_file.smp> [OPTIONS]
+```
+```
+Options:
+  -i, --input <input_file.smp>      Specify the input SMP file path and name.
+  -o, --output <output_file.ogg>    Specify the output OGG file path and name.
+  -q, --quiet                       Disable output messages.
+  -h, --help                        Show this help message and exit.
+```
+
+Alternatively, you can drag and drop an SMP file onto the executable.
+
+
+# Mass convert assets
+
+Script for batch processing multiple SMPs is available on NexusMods:
+
+[GBTVGR smp2ogg Mass Converter](https://www.nexusmods.com/ghostbustersthevideogameremastered/mods/50)

--- a/tex2dds/README.md
+++ b/tex2dds/README.md
@@ -1,0 +1,47 @@
+# Ghostbusters: The Video Game Remastered Asset Converters (tex2dds)
+
+**tex2dds:** Converts TEX files, whether from the original game (PC, PS3, Xbox 360) or the remastered version (PC), into DDS format.
+
+**Note:** The program will automatically unswizzle textures when required.
+This is necessary for certain textures used in the PS3 version and for all textures in the Xbox 360 version (the PC version does not use swizzled textures at all).
+Keep in mind that this unswizzling feature is experimental, and the resulting DDS files may not always be accurate.
+
+
+# Build Instructions:
+
+To compile this tool, use the following command:
+
+`g++ -static -o tex2dds tex2dds.cpp`
+
+To cross-compile for Windows (from Linux), use:
+
+`x86_64-w64-mingw32-g++ -static -o tex2dds tex2dds.cpp`
+
+
+# Usage:
+
+Run the converter by specifying the input TEX file:
+```sh
+$ ./tex2dds <input_file.tex> [OPTIONS]
+```
+```
+Options:
+  -i, --input <input_file.tex>      Specify the input TEX file path and name.
+  -o, --output <output_file.dds>    Specify the output DDS file path and name.
+  -q, --quiet                       Disable output messages.
+  -h, --help                        Show this help message and exit.
+```
+
+Alternatively, you can drag and drop an TEX file onto the executable.
+
+
+# Mass convert assets
+
+Script for batch processing multiple TEXs is available on NexusMods:
+
+[GBTVGR tex2dds Mass Converter](https://www.nexusmods.com/ghostbustersthevideogameremastered/mods/51)
+
+
+# Credits:
+
+The original tex2dds code was developed by Jonathan Wilson and barncastle.

--- a/tex2dds/tex2dds.cpp
+++ b/tex2dds/tex2dds.cpp
@@ -442,6 +442,7 @@ int main(int argc, char* argv[]) {
 	int blockWidthHeight;
 	int blockPixelSize;
 	int texelBytePitch;
+
 	switch (texHeader.dwFormat) {
 	case 0x27:	// PS3 OK
 		needsUnswizzle = true;


### PR DESCRIPTION
dds2tex: Adding support for swizzling textures.
This is necessary for certain textures used in the PS3 version and for all textures in the Xbox 360 version (the PC version does not require swizzling).
Keep in mind that this swizzling feature is experimental, and the resulting TEX files may be inaccurate or could potentially cause the game to crash.